### PR TITLE
Fix Vercel build errors and TypeScript issues

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(npm run lint)",
+      "Bash(npm run typecheck:*)",
+      "Bash(npm run build:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,13 +11,11 @@ import {
   TrendingUp, 
   Target, 
   Package, 
-  AlertTriangle,
   RefreshCw,
   Download,
   Store
 } from "lucide-react";
 import {
-  sampleDashboardMetrics,
   sampleChartData,
   sampleProducts,
   sampleOrders
@@ -25,7 +23,7 @@ import {
 import { CURRENT_USER_STORE, DEMO_MONTHLY_FEE_SUMMARY } from "@/data/ebay-demo-data";
 
 export default function Dashboard() {
-  const metrics = sampleDashboardMetrics;
+  // const metrics = sampleDashboardMetrics;
 
   return (
     <div className="max-w-7xl mx-auto space-y-6">

--- a/src/components/dashboard/ebay-fee-dashboard.tsx
+++ b/src/components/dashboard/ebay-fee-dashboard.tsx
@@ -3,18 +3,15 @@
 import { useState, useEffect } from 'react';
 import { GlassCard } from '@/components/ui/glass-card';
 import { 
-  DEMO_EBAY_TRANSACTIONS, 
   DEMO_MONTHLY_FEE_SUMMARY, 
   CURRENT_USER_STORE,
   EBAY_PROMOTIONS_2025,
   MonthlyFeeSummary 
 } from '@/data/ebay-demo-data';
 import { 
-  calculateAllFees, 
-  calculateMonthlyFeeSummary,
-  EBAY_FEE_RATES 
+  calculateAllFees
 } from '@/lib/ebay-fee-calculator';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { TrendingUp, TrendingDown, DollarSign, ShoppingCart, Store, Zap } from 'lucide-react';
@@ -30,7 +27,7 @@ interface FeeMetric {
 export function EbayFeeDashboard() {
   const [feeMetrics, setFeeMetrics] = useState<FeeMetric[]>([]);
   const [currentMonthData, setCurrentMonthData] = useState<MonthlyFeeSummary | null>(null);
-  const [activePromotions, setActivePromotions] = useState(EBAY_PROMOTIONS_2025);
+  const [activePromotions] = useState(EBAY_PROMOTIONS_2025);
 
   useEffect(() => {
     // 현재 월 데이터 설정
@@ -242,7 +239,7 @@ export function EbayFeeDashboard() {
                 defaultValue="100"
                 onChange={(e) => {
                   const price = parseFloat(e.target.value) || 0;
-                  const calculation = calculateAllFees(price);
+                  calculateAllFees(price);
                   // 실시간 계산 결과 업데이트 로직
                 }}
               />

--- a/src/components/dashboard/ebay-store-manager.tsx
+++ b/src/components/dashboard/ebay-store-manager.tsx
@@ -8,16 +8,13 @@ import { Progress } from '@/components/ui/progress';
 import { 
   EBAY_STORE_LEVELS, 
   CURRENT_USER_STORE,
-  EbayStoreLevel,
-  EbayStoreInfo 
+  EbayStoreLevel
 } from '@/data/ebay-demo-data';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+// import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { 
   Store, 
   Crown, 
-  TrendingUp, 
-  Package, 
   Zap, 
   CheckCircle, 
   ArrowRight,

--- a/src/components/orders/fee-breakdown.tsx
+++ b/src/components/orders/fee-breakdown.tsx
@@ -33,7 +33,7 @@ interface FeeBreakdownCardProps {
 
 // 수수료 유형별 아이콘 매핑
 const getFeeIcon = (feeType: string) => {
-  const iconMap: Record<string, React.ComponentType<any>> = {
+  const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
     'FINAL_VALUE_FEE': TrendingUp,
     'FINAL_VALUE_FEE_FIXED_PER_ORDER': Package,
     'PAYMENT_PROCESSING_FEE': CreditCard,

--- a/src/data/mock-data.ts
+++ b/src/data/mock-data.ts
@@ -96,10 +96,10 @@ export const sampleProducts: Product[] = [
 ];
 
 // eBay 거래 데이터를 주문 형태로 변환하는 헬퍼 함수
-function convertEbayTransactionToOrder(transaction: any, index: number): Order {
+function convertEbayTransactionToOrder(transaction: EbayOrder, index: number): Order {
   const orderLineItem = transaction.orderLineItems[0];
   const allFees = [...orderLineItem.fees, ...orderLineItem.marketplaceFees];
-  const totalFees = allFees.reduce((sum: number, fee: any) => sum + Math.abs(fee.amount), 0);
+  const totalFees = allFees.reduce((sum: number, fee: EbayFee) => sum + Math.abs(fee.amount), 0);
   const salePrice = parseFloat(orderLineItem.totalAmount.value);
   const estimatedPurchasePrice = salePrice * 0.6; // 추정 매입가
   const profit = salePrice - totalFees - estimatedPurchasePrice;
@@ -107,8 +107,8 @@ function convertEbayTransactionToOrder(transaction: any, index: number): Order {
   
   // 프로모션 절약 계산
   const promotionSavings = allFees
-    .filter((fee: any) => fee.feeMemo.includes('할인') || fee.feeMemo.includes('50%'))
-    .reduce((sum: number, fee: any) => sum + Math.abs(fee.amount), 0);
+    .filter((fee: EbayFee) => fee.feeMemo.includes('할인') || fee.feeMemo.includes('50%'))
+    .reduce((sum: number, fee: EbayFee) => sum + Math.abs(fee.amount), 0);
 
   return {
     id: (index + 1).toString(),
@@ -120,12 +120,12 @@ function convertEbayTransactionToOrder(transaction: any, index: number): Order {
     salePrice,
     purchasePrice: estimatedPurchasePrice,
     fees: {
-      platformFee: allFees.filter((f: any) => f.feeType.includes('FINAL_VALUE')).reduce((sum: number, fee: any) => sum + Math.abs(fee.amount), 0),
-      paymentFee: allFees.filter((f: any) => f.feeType === 'PAYMENT_PROCESSING_FEE').reduce((sum: number, fee: any) => sum + Math.abs(fee.amount), 0),
-      shippingFee: allFees.filter((f: any) => f.feeType.includes('SHIPPING')).reduce((sum: number, fee: any) => sum + Math.abs(fee.amount), 0),
-      promotionFee: allFees.filter((f: any) => f.feeType.includes('AD_FEE') || f.feeType.includes('PROMOTED')).reduce((sum: number, fee: any) => sum + Math.abs(fee.amount), 0),
-      tax: allFees.filter((f: any) => f.feeType.includes('TAX')).reduce((sum: number, fee: any) => sum + Math.abs(fee.amount), 0),
-      others: allFees.filter((f: any) => !['FINAL_VALUE_FEE', 'PAYMENT_PROCESSING_FEE', 'AD_FEE', 'PROMOTED_LISTINGS_FEE'].some(type => f.feeType.includes(type))).reduce((sum: number, fee: any) => sum + Math.abs(fee.amount), 0)
+      platformFee: allFees.filter((f: EbayFee) => f.feeType.includes('FINAL_VALUE')).reduce((sum: number, fee: EbayFee) => sum + Math.abs(fee.amount), 0),
+      paymentFee: allFees.filter((f: EbayFee) => f.feeType === 'PAYMENT_PROCESSING_FEE').reduce((sum: number, fee: EbayFee) => sum + Math.abs(fee.amount), 0),
+      shippingFee: allFees.filter((f: EbayFee) => f.feeType.includes('SHIPPING')).reduce((sum: number, fee: EbayFee) => sum + Math.abs(fee.amount), 0),
+      promotionFee: allFees.filter((f: EbayFee) => f.feeType.includes('AD_FEE') || f.feeType.includes('PROMOTED')).reduce((sum: number, fee: EbayFee) => sum + Math.abs(fee.amount), 0),
+      tax: allFees.filter((f: EbayFee) => f.feeType.includes('TAX')).reduce((sum: number, fee: EbayFee) => sum + Math.abs(fee.amount), 0),
+      others: allFees.filter((f: EbayFee) => !['FINAL_VALUE_FEE', 'PAYMENT_PROCESSING_FEE', 'AD_FEE', 'PROMOTED_LISTINGS_FEE'].some(type => f.feeType.includes(type))).reduce((sum: number, fee: EbayFee) => sum + Math.abs(fee.amount), 0)
     },
     profit,
     marginRate,

--- a/src/hooks/use-real-time-pricing.ts
+++ b/src/hooks/use-real-time-pricing.ts
@@ -58,7 +58,7 @@ export function useRealTimePricing(
         targetMargin: debouncedTargetMargin,
         priceChange,
         marginChange,
-        feeCalculation: optimalPricing.feeCalculation
+        feeCalculation: optimalPricing.profitAnalysis.feeCalculation
       };
     });
   }, [recommendations, debouncedTargetMargin, riskLevel]);

--- a/src/lib/ebay-fee-calculator.ts
+++ b/src/lib/ebay-fee-calculator.ts
@@ -151,7 +151,7 @@ export function calculateListingFees(
   storeLevel: EbayStoreLevel = CURRENT_USER_STORE.storeLevel
 ): ListingFeeCalculationResult {
   const storeInfo = EBAY_STORE_LEVELS[storeLevel];
-  const freeListingsUsed = Math.min(listingCount, storeInfo.freeListings);
+  // const freeListingsUsed = Math.min(listingCount, storeInfo.freeListings);
   const paidListings = Math.max(listingCount - storeInfo.freeListings, 0);
   
   const insertionFee = paidListings * storeInfo.additionalListingFee;
@@ -283,7 +283,7 @@ export function calculateMonthlyFeeSummary(
 ): {
   totalSales: number;
   totalFees: number;
-  feeBreakdown: Record<EbayFeeType, number>;
+  feeBreakdown: Partial<Record<EbayFeeType, number>>;
   storeSubscriptionFee: number;
   totalSavings: number;
 } {
@@ -292,7 +292,7 @@ export function calculateMonthlyFeeSummary(
   const totalFees = allFees.reduce((sum, fee) => sum + fee.amount, 0);
   
   // 수수료 유형별 분류
-  const feeBreakdown: Record<EbayFeeType, number> = {
+  const feeBreakdown: Partial<Record<EbayFeeType, number>> = {
     FINAL_VALUE_FEE: 0,
     INSERTION_FEE: 0,
     PAYMENT_PROCESSING_FEE: 0,
@@ -301,18 +301,17 @@ export function calculateMonthlyFeeSummary(
     INTERNATIONAL_FEE: 0,
     SUBTITLE_FEE: 0,
     LISTING_UPGRADE_FEE: 0,
-    MANAGED_PAYMENTS_FEE: 0,
     BELOW_STANDARD_FEE: 0
   };
   
   allFees.forEach(fee => {
-    feeBreakdown[fee.feeType] += fee.amount;
+    feeBreakdown[fee.feeType] = (feeBreakdown[fee.feeType] || 0) + fee.amount;
   });
   
   // 스토어 구독료 추가
   const storeInfo = EBAY_STORE_LEVELS[storeLevel];
   const storeSubscriptionFee = storeInfo.monthlyFee;
-  feeBreakdown.STORE_SUBSCRIPTION_FEE += storeSubscriptionFee;
+  feeBreakdown.STORE_SUBSCRIPTION_FEE = (feeBreakdown.STORE_SUBSCRIPTION_FEE || 0) + storeSubscriptionFee;
   
   // 프로모션으로 절약한 금액 계산
   const totalSavings = transactions.reduce((sum, t) => {


### PR DESCRIPTION
- Replace 'any' types with proper TypeScript interfaces (EbayFee, EbayOrder)
- Fix TypeScript errors in fee-breakdown.tsx and mock-data.ts
- Remove unused imports and variables across components
- Fix type issues in ebay-fee-calculator.ts
- Update fee breakdown types to use Partial<Record<EbayFeeType, number>>
- Handle undefined values in fee calculations

🤖 Generated with [Claude Code](https://claude.ai/code)